### PR TITLE
Add Guzzle 7 & Symfony 5/6 Support, Refactor Middleware, Drop PHP 7 & Symfony 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
         dependencies:
           - lowest
           - highest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [2.1.0] - 2023-04-17
 
 ### Added
 
-- Add PHP 8 support.
-- Add PHPUnit 8 and 9 compatibility.
+- Add PHP 8 support
+- Add PHPUnit 8 and 9 compatibility
+- Add CI via github actions
+- Add guzzle IDN_CONVERSION feature
+- Add phpunit dependencies
 
 ### Changed
 
 - Change the constructor signature of `AbstractApiClient` to make the first parameter non-optional. This modification should not cause any BC breaks because the second parameter was not optional either.
+- Update phpunit.xml.dist
 
 ### Removed
 
-- Remove PHP 7.1 compatibility.
-- Remove phpunit 7 compatibility.
+- Remove PHP 7.1 compatibility
+- Remove phpunit 7 compatibility
+- Delete composer.lock
+- Remove travis configuration
 
 ## [2.0.2] - 2018-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.0] - 2025-06-15
+
+### Added
+
+- Add Guzzle 7 support
+- Add Symfony 5 and 6 support
+- Add unit tests for middleware classes
+
+### Changed
+
+- **Breaking:** Refactor deserialization middleware for compatibility with Guzzle 7. `DeserializeResponseMiddleware` now always returns a `Psr\Http\Message\ResponseInterface`. Previously, it returned the deserialized data directly. Refer to the updated [README.md](README.md) for guidance on using the new middleware behavior.
+- Replace deprecated `stream_for` usage with `Utils::streamFor`
+- Replace deprecated `rejection_for` with `Create::rejectionFor`
+
+### Removed
+
+- **Breaking:** Remove PHP 7 compatibility
+- **Breaking:** Remove Symfony 4 support
+
+
 ## [2.1.0] - 2023-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ class MyClient extends AbstractApiClient {
      */
     public function get(int $id):Model
     {
-        return $this->http->get('model/'.$id, [
+        $response $this->http->get('model/'.$id, [
             'deserialize_to' => Model::class
         ]);
+
+        if (!$response instanceof DeserializedResponse) {
+            throw new \RuntimeException('Expected a DeserializedResponse, got: '.get_class($response));
+        }
+
+        return $response->getDeserializedData();
     }
 
 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "A simple client for JSON APIs using Guzzle and the Symfony Serializer.",
     "type": "library",
     "require": {
-        "php": "^7.2 || ^8.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "symfony/serializer": "^4.0",
-        "symfony/options-resolver": "^4.0"
+        "php": "^8.0",
+        "guzzlehttp/guzzle": "^6.5 || ^7.4",
+        "symfony/serializer": "^5.4 || ^6.4",
+        "symfony/options-resolver": "^5.4 || ^6.4"
     },
     "license": "MIT",
     "authors": [
@@ -26,7 +26,12 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.23 || ^9",
-        "psr/log": "^1.0"
+        "phpunit/phpunit": "^9.6",
+        "psr/log": "^3.0"
+    },
+    "conflict": {
+        "guzzlehttp/guzzle": "<6.5.8",
+        "psr/http-message": "<1.1",
+        "guzzlehttp/promises": "<1.4"
     }
 }

--- a/src/HttpMessage/DeserializedResponse.php
+++ b/src/HttpMessage/DeserializedResponse.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace TS\Web\JsonClient\HttpMessage;
+
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class DeserializedResponse implements ResponseInterface
+{
+    public function __construct(private ResponseInterface $response, private object $data)
+    {
+    }
+
+    public function getDeserializedData(): object
+    {
+        return $this->data;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getProtocolVersion(): string
+    {
+        return $this->response->getProtocolVersion();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withProtocolVersion(string $version): MessageInterface
+    {
+        return $this->response->withProtocolVersion($version);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasHeader(string $name): bool
+    {
+        return $this->response->hasHeader($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHeader(string $name): array
+    {
+        return $this->response->getHeader($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHeaderLine(string $name): string
+    {
+        return $this->response->getHeaderLine($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withHeader(string $name, $value): MessageInterface
+    {
+        return $this->response->withHeader($name, $value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withAddedHeader(string $name, $value): MessageInterface
+    {
+        return $this->response->withAddedHeader($name, $value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withoutHeader(string $name): MessageInterface
+    {
+        return $this->response->withoutHeader($name);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBody(): StreamInterface
+    {
+        return $this->response->getBody();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withBody(StreamInterface $body): MessageInterface
+    {
+        return $this->response->withBody($body);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
+    {
+        return $this->response->withStatus($code, $reasonPhrase);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getReasonPhrase(): string
+    {
+        return $this->response->getReasonPhrase();
+    }
+}

--- a/src/Middleware/DeserializeResponseMiddleware.php
+++ b/src/Middleware/DeserializeResponseMiddleware.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
+use TS\Web\JsonClient\HttpMessage\DeserializedResponse;
 
 
 /**
@@ -91,17 +92,17 @@ class DeserializeResponseMiddleware
 
             if (is_string($deserialize_to)) {
 
-                return $deserializer->deserializeBody($deserialize_to);
+                $deserialized = $deserializer->deserializeBody($deserialize_to);
+                $response = new DeserializedResponse($response, $deserialized);
 
             } else if (is_callable($deserialize_to)) {
 
-                return $deserialize_to($deserializer);
-
-            } else {
-
-                return $response;
+                $deserialized = $deserialize_to($deserializer);
+                $response = new DeserializedResponse($response, $deserialized);
 
             }
+
+            return $response;
         });
 
     }

--- a/src/Middleware/HttpLoggingMiddleware.php
+++ b/src/Middleware/HttpLoggingMiddleware.php
@@ -10,11 +10,11 @@ namespace TS\Web\JsonClient\Middleware;
 
 
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TS\Web\JsonClient\HttpLogging\HttpNullLogger;
-use function GuzzleHttp\Promise\rejection_for;
 
 
 /**
@@ -61,7 +61,7 @@ class HttpLoggingMiddleware
                 $transferTimeSeconds = $transferStart + microtime(true);
                 $logger->logFailure($request, $response, $reason, $options, $transferTimeSeconds);
 
-                return rejection_for($reason);
+                return Create::rejectionFor($reason);
             });
         };
     }

--- a/src/Middleware/SerializeRequestBodyMiddleware.php
+++ b/src/Middleware/SerializeRequestBodyMiddleware.php
@@ -9,9 +9,9 @@
 namespace TS\Web\JsonClient\Middleware;
 
 
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use function GuzzleHttp\Psr7\stream_for;
 
 
 class SerializeRequestBodyMiddleware
@@ -40,7 +40,7 @@ class SerializeRequestBodyMiddleware
         $json = $this->serializer
             ->serialize($options['data'], 'json', $context);
 
-        $body = stream_for($json);
+        $body = Utils::streamFor($json);
 
         $request = $request
             ->withHeader('Content-Type', 'application/json')

--- a/src/Middleware/ServerMessageMiddleware.php
+++ b/src/Middleware/ServerMessageMiddleware.php
@@ -9,13 +9,13 @@
 namespace TS\Web\JsonClient\Middleware;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use TS\Web\JsonClient\Exception\ServerMessageException;
 use TS\Web\JsonClient\Exception\UnexpectedResponseException;
 use function GuzzleHttp\json_decode;
-use function GuzzleHttp\Psr7\stream_for;
 
 
 /**
@@ -71,7 +71,7 @@ class ServerMessageMiddleware
         $body = $response->getBody()->getContents();
 
         // restore response body
-        $response = $response->withBody(stream_for($body));
+        $response = $response->withBody(Utils::streamFor($body));
 
         try {
 

--- a/tests/AbstractClientTest.php
+++ b/tests/AbstractClientTest.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -23,7 +24,6 @@ use TS\Web\JsonClient\Exception\ServerMessageException;
 use TS\Web\JsonClient\Exception\UnexpectedResponseException;
 use TS\Web\JsonClient\Fixtures\Payload;
 use TS\Web\JsonClient\Fixtures\TestClient;
-use function GuzzleHttp\Psr7\stream_for;
 
 
 class AbstractClientTest extends TestCase
@@ -58,7 +58,7 @@ class AbstractClientTest extends TestCase
     {
         $history = [];
         $this->handlerStack->push(Middleware::history($history));
-        $this->mockHandler->append(new Response(200, ['Content-Type' => 'application/json'], stream_for('{"message":"Hello"}')));
+        $this->mockHandler->append(new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('{"message":"Hello"}')));
 
         $this->client->getBodyString();
 
@@ -78,7 +78,7 @@ class AbstractClientTest extends TestCase
             ->willThrowException(new \RuntimeException('serializer error'));
 
         $this->mockHandler->append(
-            new Response(200, ['Content-Type' => 'application/json'], stream_for('placeholder-payload-json'))
+            new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('placeholder-payload-json'))
         );
 
         $this->expectException(UnexpectedResponseException::class);
@@ -98,7 +98,7 @@ class AbstractClientTest extends TestCase
             ->willReturn($payload);
 
         $this->mockHandler->append(
-            new Response(200, ['Content-Type' => 'application/json'], stream_for('placeholder-payload-json'))
+            new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('placeholder-payload-json'))
         );
 
         $result = $this->client->getPayload();
@@ -201,7 +201,7 @@ class AbstractClientTest extends TestCase
             new Response(
                 $responseStatus,
                 ['Content-Type' => 'application/json'],
-                stream_for($responseBody)
+                Utils::streamFor($responseBody)
             )
         );
 

--- a/tests/ClientOptionsTest.php
+++ b/tests/ClientOptionsTest.php
@@ -56,8 +56,15 @@ class ClientOptionsTest extends TestCase
 
     public function provideDefinedOptions()
     {
+        $invalidOptions = [
+            'crypto_method',
+        ];
+        
         $class = new \ReflectionClass(RequestOptions::class);
         foreach ($class->getConstants() as $constant) {
+            if (in_array($constant, $invalidOptions)) {
+                continue;
+            }
             $value = 'test';
             if ($constant === RequestOptions::HEADERS) {
                 $value = [];

--- a/tests/Fixtures/TestClient.php
+++ b/tests/Fixtures/TestClient.php
@@ -11,6 +11,7 @@ namespace TS\Web\JsonClient\Fixtures;
 
 use TS\Web\JsonClient\AbstractApiClient;
 use TS\Web\JsonClient\Exception\ResponseExpector;
+use TS\Web\JsonClient\HttpMessage\DeserializedResponse;
 
 class TestClient extends AbstractApiClient
 {
@@ -42,9 +43,15 @@ class TestClient extends AbstractApiClient
 
     public function getPayload(): Payload
     {
-        return $this->http->get('get-payload', [
+        $response = $this->http->get('get-payload', [
             'deserialize_to' => Payload::class
         ]);
+
+        if (!$response instanceof DeserializedResponse) {
+            throw new \RuntimeException('Expected a DeserializedResponse, got: '.get_class($response));
+        }
+
+        return $response->getDeserializedData();
     }
 
 

--- a/tests/Middleware/DeserializeResponseMiddlewareTest.php
+++ b/tests/Middleware/DeserializeResponseMiddlewareTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+use TS\Web\JsonClient\Exception\UnexpectedResponseException;
+use TS\Web\JsonClient\Fixtures\Payload;
+
+class DeserializeResponseMiddlewareTest extends TestCase
+{
+    private $middleware;
+    private $nextHandler;
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('{"id": 1, "name": "test"}'));
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new DeserializeResponseMiddleware($this->nextHandler, $this->serializer);
+    }
+
+    public function testSuccessfulDeserialization()
+    {
+        $payload = new Payload('test', 1);
+        $this->serializer->expects($this->once())
+            ->method('deserialize')
+            ->with('{"id": 1, "name": "test"}', Payload::class)
+            ->willReturn($payload);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $request->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $options = ['deserialize_to' => Payload::class];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertSame($payload, $response);
+    }
+
+    public function testNonJsonResponseThrowsException()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, [], Utils::streamFor('not json'));
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new DeserializeResponseMiddleware($this->nextHandler, $this->serializer);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $request->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $options = ['deserialize_to' => Payload::class];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Expected response content type to be application/json, got  instead.');
+
+        $promise->wait();
+    }
+
+    public function testSerializerExceptionThrowsUnexpectedResponseException()
+    {
+        $this->serializer->expects($this->once())
+            ->method('deserialize')
+            ->willThrowException(new \Exception('Serialization error'));
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $request->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $options = ['deserialize_to' => Payload::class];
+
+        $nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('{"id": 1, "name": "test"}'));
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $middleware = new DeserializeResponseMiddleware($nextHandler, $this->serializer);
+        $promise = $middleware->__invoke($request, $options);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Failed to deserialize response body to type TS\Web\JsonClient\Fixtures\Payload: Serialization error');
+
+        $promise->wait();
+    }
+
+    public function testNoDeserializeToOptionReturnsOriginalResponse()
+    {
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $request->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $options = [];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Middleware/DeserializeResponseMiddlewareTest.php
+++ b/tests/Middleware/DeserializeResponseMiddlewareTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 use TS\Web\JsonClient\Exception\UnexpectedResponseException;
 use TS\Web\JsonClient\Fixtures\Payload;
+use TS\Web\JsonClient\HttpMessage\DeserializedResponse;
 
 class DeserializeResponseMiddlewareTest extends TestCase
 {
@@ -45,8 +46,9 @@ class DeserializeResponseMiddlewareTest extends TestCase
 
         $promise = $this->middleware->__invoke($request, $options);
         $response = $promise->wait();
+        $this->assertInstanceOf(DeserializedResponse::class, $response);
 
-        $this->assertSame($payload, $response);
+        $this->assertSame($payload, $response->getDeserializedData());
     }
 
     public function testNonJsonResponseThrowsException()

--- a/tests/Middleware/HttpLoggingMiddlewareTest.php
+++ b/tests/Middleware/HttpLoggingMiddlewareTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use TS\Web\JsonClient\HttpLogging\HttpLoggerInterface;
+
+class HttpLoggingMiddlewareTest extends TestCase
+{
+    private $middleware;
+    private $nextHandler;
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(HttpLoggerInterface::class);
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor('{"id": 1}'));
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new HttpLoggingMiddleware($this->nextHandler, $this->logger);
+    }
+
+    public function testSuccessfulRequestLogging()
+    {
+        $request = new Request('GET', 'http://example.com');
+        $options = ['logger' => $this->logger];
+
+        $this->logger->expects($this->once())
+            ->method('logStart')
+            ->with($request, $options)
+            ->willReturn($request);
+
+        $this->logger->expects($this->once())
+            ->method('logSuccess')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $options,
+                $this->anything()
+            );
+
+        $handler = $this->middleware->__invoke($this->nextHandler);
+        $promise = $handler($request, $options);
+        $response = $promise->wait();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testFailedRequestLogging()
+    {
+        $request = new Request('GET', 'http://example.com');
+        $options = ['logger' => $this->logger];
+        $exception = new RequestException('Error', $request);
+
+        $this->nextHandler = function ($request, $options) use ($exception) {
+            return Create::rejectionFor($exception);
+        };
+        $this->middleware = new HttpLoggingMiddleware($this->nextHandler, $this->logger);
+
+        $this->logger->expects($this->once())
+            ->method('logStart')
+            ->with($request, $options)
+            ->willReturn($request);
+
+        $this->logger->expects($this->once())
+            ->method('logFailure')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $options,
+                $this->anything()
+            );
+
+        $handler = $this->middleware->__invoke($this->nextHandler);
+        $promise = $handler($request, $options);
+
+        $this->expectException(RequestException::class);
+        $promise->wait();
+    }
+
+    public function testUsesNullLoggerWhenNoLoggerProvided()
+    {
+        $request = new Request('GET', 'http://example.com');
+        $options = [];
+
+        $handler = $this->middleware->__invoke($this->nextHandler);
+        $promise = $handler($request, $options);
+        $response = $promise->wait();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testTransferTimeIsCalculated()
+    {
+        $request = new Request('GET', 'http://example.com');
+        $options = ['logger' => $this->logger];
+
+        $this->logger->expects($this->once())
+            ->method('logStart')
+            ->with($request, $options)
+            ->willReturn($request);
+
+        $this->logger->expects($this->once())
+            ->method('logSuccess')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $options,
+                $this->callback(function ($transferTime) {
+                    return is_float($transferTime) && $transferTime > 0;
+                })
+            );
+
+        $handler = $this->middleware->__invoke($this->nextHandler);
+        $promise = $handler($request, $options);
+        $promise->wait();
+    }
+
+    public function testRequestIsModifiedByLogger()
+    {
+        $originalRequest = new Request('GET', 'http://example.com');
+        $modifiedRequest = new Request('POST', 'http://example.com');
+        $options = ['logger' => $this->logger];
+
+        $this->logger->expects($this->once())
+            ->method('logStart')
+            ->with($originalRequest, $options)
+            ->willReturn($modifiedRequest);
+
+        $this->nextHandler = function ($request, $options) use ($modifiedRequest) {
+            $this->assertEquals('POST', $request->getMethod());
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new HttpLoggingMiddleware($this->nextHandler, $this->logger);
+
+        $handler = $this->middleware->__invoke($this->nextHandler);
+        $promise = $handler($originalRequest, $options);
+        $promise->wait();
+    }
+}

--- a/tests/Middleware/ResponseDeserializerTest.php
+++ b/tests/Middleware/ResponseDeserializerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use TS\Web\JsonClient\Exception\UnexpectedResponseException;
+use TS\Web\JsonClient\Fixtures\Payload;
+
+class ResponseDeserializerTest extends TestCase
+{
+    private $serializer;
+    private $request;
+    private $response;
+    private $context;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->request = $this->createMock(RequestInterface::class);
+        $this->context = ['foo' => 'bar'];
+    }
+
+    public function testSuccessfulDeserialization()
+    {
+        $payload = new Payload('str', 123);
+        $json = '{"str":"str","int":123}';
+        $this->response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor($json));
+
+        $this->serializer->expects($this->once())
+            ->method('deserialize')
+            ->with($json, Payload::class, 'json', $this->context)
+            ->willReturn($payload);
+
+        $this->request->expects($this->once())
+            ->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $deserializer = new ResponseDeserializer($this->serializer, $this->context, $this->request, $this->response);
+        $result = $deserializer->deserializeBody(Payload::class);
+        $this->assertSame($payload, $result);
+    }
+
+    public function testContentTypeMismatchThrowsException()
+    {
+        $json = '{"str":"str","int":123}';
+        $this->response = new Response(200, ['Content-Type' => 'text/html'], Utils::streamFor($json));
+
+        $deserializer = new ResponseDeserializer($this->serializer, $this->context, $this->request, $this->response);
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Expected response content type to be application/json, got text/html instead.');
+        $deserializer->deserializeBody(Payload::class);
+    }
+
+    public function testSerializerExceptionThrowsUnexpectedResponseException()
+    {
+        $json = '{"str":"str","int":123}';
+        $this->response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor($json));
+
+        $this->serializer->expects($this->once())
+            ->method('deserialize')
+            ->willThrowException(new \Exception('serializer error'));
+
+        $this->request->expects($this->once())
+            ->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $deserializer = new ResponseDeserializer($this->serializer, $this->context, $this->request, $this->response);
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Failed to deserialize response body to type TS\Web\JsonClient\Fixtures\Payload: serializer error');
+        $deserializer->deserializeBody(Payload::class);
+    }
+
+    public function testContextMerging()
+    {
+        $payload = new Payload('str', 123);
+        $json = '{"str":"str","int":123}';
+        $this->response = new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor($json));
+
+        $customContext = ['foo' => 'baz', 'bar' => 'baz'];
+        $expectedContext = ['foo' => 'baz', 'bar' => 'baz'];
+
+        $this->serializer->expects($this->once())
+            ->method('deserialize')
+            ->with($json, Payload::class, 'json', $expectedContext)
+            ->willReturn($payload);
+
+        $this->request->expects($this->once())
+            ->method('getBody')
+            ->willReturn(Utils::streamFor(''));
+
+        $deserializer = new ResponseDeserializer($this->serializer, $this->context, $this->request, $this->response);
+        $result = $deserializer->deserializeBody(Payload::class, $customContext);
+        $this->assertSame($payload, $result);
+    }
+}

--- a/tests/Middleware/ResponseExpectationMiddlewareTest.php
+++ b/tests/Middleware/ResponseExpectationMiddlewareTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use TS\Web\JsonClient\Exception\UnexpectedResponseException;
+
+class ResponseExpectationMiddlewareTest extends TestCase
+{
+    private $middleware;
+    private $nextHandler;
+
+    protected function setUp(): void
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+    }
+
+    public function testSuccessfulResponsePassesThrough()
+    {
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testExpectedContentTypePassesThrough()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'application/json']);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [ResponseExpectationMiddleware::REQUEST_OPTION_EXPECT_RESPONSE_TYPE => 'application/json'];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testUnexpectedContentTypeThrowsException()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'text/html']);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [ResponseExpectationMiddleware::REQUEST_OPTION_EXPECT_RESPONSE_TYPE => 'application/json'];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Expected response content type to be application/json, got text/html instead.');
+
+        $promise->wait();
+    }
+
+    public function testMissingContentTypeThrowsException()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [ResponseExpectationMiddleware::REQUEST_OPTION_EXPECT_RESPONSE_TYPE => 'application/json'];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Expected response content type to be application/json, got  instead.');
+
+        $promise->wait();
+    }
+
+    public function testNoExpectationOptionPassesThrough()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'text/html']);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/html', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function testMultipleContentTypesInHeader()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200, ['Content-Type' => 'application/json; charset=utf-8']);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ResponseExpectationMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [ResponseExpectationMiddleware::REQUEST_OPTION_EXPECT_RESPONSE_TYPE => 'application/json'];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+    }
+}

--- a/tests/Middleware/SerializeRequestBodyMiddlewareTest.php
+++ b/tests/Middleware/SerializeRequestBodyMiddlewareTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+use TS\Web\JsonClient\Fixtures\Payload;
+
+class SerializeRequestBodyMiddlewareTest extends TestCase
+{
+    private $serializer;
+    private $middleware;
+    private $nextHandler;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise, $request) {
+                $promise->resolve($request);
+            });
+            return $promise;
+        };
+        $this->middleware = new SerializeRequestBodyMiddleware($this->nextHandler, $this->serializer);
+    }
+
+    public function testSuccessfulSerialization()
+    {
+        $payload = new Payload('test', 123);
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with($payload, 'json')
+            ->willReturn('{"message":"test","value":123}');
+
+        $request = new Request('POST', 'http://example.com', ['Content-Type' => 'application/json']);
+        $options = ['data' => $payload];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $modifiedRequest = $promise->wait();
+
+        $this->assertEquals('application/json', $modifiedRequest->getHeaderLine('Content-Type'));
+        $this->assertEquals('{"message":"test","value":123}', (string)$modifiedRequest->getBody());
+    }
+
+    public function testNoDataOptionReturnsOriginalRequest()
+    {
+        $request = new Request('GET', 'http://example.com');
+        $options = [];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $modifiedRequest = $promise->wait();
+
+        $this->assertSame($request, $modifiedRequest);
+    }
+
+    public function testSerializerExceptionPropagates()
+    {
+        $payload = new Payload('test', 123);
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->willThrowException(new \RuntimeException('Serializer error'));
+
+        $request = new Request('POST', 'http://example.com', ['Content-Type' => 'application/json']);
+        $options = ['data' => $payload];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Serializer error');
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $promise->wait();
+    }
+
+    public function testNonObjectPayloadHandling()
+    {
+        $payload = ['message' => 'test', 'value' => 123];
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with($payload, 'json')
+            ->willReturn('{"message":"test","value":123}');
+
+        $request = new Request('POST', 'http://example.com', ['Content-Type' => 'application/json']);
+        $options = ['data' => $payload];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $modifiedRequest = $promise->wait();
+
+        $this->assertEquals('application/json', $modifiedRequest->getHeaderLine('Content-Type'));
+        $this->assertEquals('{"message":"test","value":123}', (string)$modifiedRequest->getBody());
+    }
+
+    public function testDataContextOptionIsPassedToSerializer()
+    {
+        $payload = new Payload('test', 123);
+        $context = ['foo' => 'bar'];
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with($payload, 'json', $context)
+            ->willReturn('{"message":"test","value":123}');
+
+        $request = new Request('POST', 'http://example.com', ['Content-Type' => 'application/json']);
+        $options = ['data' => $payload, 'data_context' => $context];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $modifiedRequest = $promise->wait();
+
+        $this->assertEquals('application/json', $modifiedRequest->getHeaderLine('Content-Type'));
+        $this->assertEquals('{"message":"test","value":123}', (string)$modifiedRequest->getBody());
+    }
+}

--- a/tests/Middleware/ServerMessageMiddlewareTest.php
+++ b/tests/Middleware/ServerMessageMiddlewareTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace TS\Web\JsonClient\Middleware;
+
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\TestCase;
+use TS\Web\JsonClient\Exception\ServerMessageException;
+use TS\Web\JsonClient\Exception\UnexpectedResponseException;
+
+class ServerMessageMiddlewareTest extends TestCase
+{
+    private $middleware;
+    private $nextHandler;
+
+    protected function setUp(): void
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(200);
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ServerMessageMiddleware($this->nextHandler);
+    }
+
+    public function testSuccessfulResponsePassesThrough()
+    {
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [RequestOptions::HTTP_ERRORS => true];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testJsonErrorResponseThrowsServerMessageException()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(
+                    400,
+                    ['Content-Type' => 'application/json'],
+                    Utils::streamFor('{"message":"Invalid input","details":"Field X is required","request_id":"123"}')
+                );
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ServerMessageMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [RequestOptions::HTTP_ERRORS => true];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        $this->expectException(ServerMessageException::class);
+        $this->expectExceptionMessage('Invalid input');
+
+        $promise->wait();
+    }
+
+    public function testNonJsonErrorResponsePassesThrough()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(
+                    400,
+                    ['Content-Type' => 'text/plain'],
+                    Utils::streamFor('Invalid input')
+                );
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ServerMessageMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [RequestOptions::HTTP_ERRORS => true];
+
+        $promise = $this->middleware->__invoke($request, $options);
+        $response = $promise->wait();
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals('Invalid input', (string)$response->getBody());
+    }
+
+    public function testInvalidJsonErrorResponseThrowsUnexpectedResponseException()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(
+                    400,
+                    ['Content-Type' => 'application/json'],
+                    Utils::streamFor('{invalid json}')
+                );
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ServerMessageMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [RequestOptions::HTTP_ERRORS => true];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Failed to decode json response: json_decode error: Syntax error');
+
+        $promise->wait();
+    }
+
+    public function testServerMessageExceptionContainsAllFields()
+    {
+        $this->nextHandler = function ($request, $options) {
+            $promise = new Promise(function () use (&$promise) {
+                $response = new Response(
+                    400,
+                    ['Content-Type' => 'application/json'],
+                    Utils::streamFor('{"message":"Invalid input","details":"Field X is required","request_id":"123"}')
+                );
+                $promise->resolve($response);
+            });
+            return $promise;
+        };
+        $this->middleware = new ServerMessageMiddleware($this->nextHandler);
+
+        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $options = [RequestOptions::HTTP_ERRORS => true];
+
+        $promise = $this->middleware->__invoke($request, $options);
+
+        try {
+            $promise->wait();
+            $this->fail('Expected ServerMessageException was not thrown');
+        } catch (ServerMessageException $e) {
+            $this->assertEquals('Invalid input', $e->getMessage());
+            $this->assertEquals('Field X is required', $e->getDetails());
+            $this->assertEquals('123', $e->getRequestId());
+        }
+    }
+}


### PR DESCRIPTION
## [3.0.0] - 2025-06-15

### Added

- Add Guzzle 7 support
- Add Symfony 5 and 6 support
- Add unit tests for middleware classes

### Changed

- **Breaking:** Refactor deserialization middleware for compatibility with Guzzle 7. `DeserializeResponseMiddleware` now always returns a `Psr\Http\Message\ResponseInterface`. Previously, it returned the deserialized data directly. Refer to the updated [README.md](README.md) for guidance on using the new middleware behavior.
- Replace deprecated `stream_for` usage with `Utils::streamFor`
- Replace deprecated `rejection_for` with `Create::rejectionFor`

### Removed

- **Breaking:** Remove PHP 7 compatibility
- **Breaking:** Remove Symfony 4 support