### PR TITLE
Modernize PHP Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
           - 8.1
           - 8.2
           - 8.3
+          - 8.4
         dependencies:
           - lowest
           - highest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.0] - 2025-09-15
+
+### Added
+
+- Add support for 8.4
+- Add PHP 8.4 to the GitHub Actions CI test matrix
+- Bump PHPUnit to version 9.6.20 for PHP 8.4 compatibility
+
+
 ## [3.0.0] - 2025-06-15
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.20",
         "psr/log": "^3.0"
     },
     "conflict": {


### PR DESCRIPTION
This merge request modernizes the json-client library by updating PHP and PHPUnit support and updating GitHub Actions CI.

## Changes

- Updates PHPUnit to version 9.6.20 for PHP 8.4 compatibility
- Add PHP 8.4 to the GitHub Actions CI test matrix
